### PR TITLE
fix: doc link for editing on github

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,9 +77,9 @@ last_edit_time_format: "%b %e %Y at %I:%M %p"
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "GitHub'ta düzenle."
-gh_edit_repository: "https://github.com/k8s-tr/k8s-docs/" 
-gh_edit_branch: "master" 
-gh_edit_view_mode: "tree" 
+gh_edit_repository: "https://github.com/k8s-tr/k8s-docs/"
+gh_edit_branch: "gh-pages"
+gh_edit_view_mode: "blob"
 
 include:
     - docs


### PR DESCRIPTION
su anki halinde footer kisminda ki "GitHub'ta duzenle." kismina basinca resimdeki hatayi verdigi icin, duzenleme icin PR actim.

<img width="1360" height="304" alt="image" src="https://github.com/user-attachments/assets/5c048cbc-8a7b-41b4-9bc5-5f0bf26a1047" />
